### PR TITLE
Fix PrivacyToggle imports to use .jsx extension

### DIFF
--- a/pages/Dashboard.jsx
+++ b/pages/Dashboard.jsx
@@ -18,7 +18,7 @@ import { User } from "@/api/entities";
 import UpcomingDue from "@/components/dashboard/UpcomingDue";
 import { generateReminders } from "@/api/functions";
 import { emailUpcomingBills } from "@/api/functions";
-import PrivacyToggle from "@/components/shared/PrivacyToggle.js";
+import PrivacyToggle from "@/components/shared/PrivacyToggle.jsx";
 import { useIdlePrefetch } from "../components/hooks/useIdlePrefetch";
 // Replace the OnboardingModal import to avoid extension-specific path issues
 import OnboardingModal from "@/components/onboarding/OnboardingModal";

--- a/pages/Layout.jsx
+++ b/pages/Layout.jsx
@@ -45,7 +45,7 @@ import useGamification from "./components/hooks/useGamification";
 import { User as UserEntity } from "@/api/entities";
 import CommandPalette from "./components/shared/CommandPalette";
 import NotificationsCenter from "./components/shared/NotificationsCenter.js";
-import PrivacyToggle from "./components/shared/PrivacyToggle.js";
+import PrivacyToggle from "./components/shared/PrivacyToggle.jsx";
 
 const navigationItems = [
     {

--- a/pages/Settings.jsx
+++ b/pages/Settings.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { User } from "@/api/entities";
 import { useTheme } from "@/components/theme/ThemeProvider";
 import { ThemeSelector } from "@/components/theme/ThemeToggle";
-import PrivacyToggle from "@/components/shared/PrivacyToggle.js";
+import PrivacyToggle from "@/components/shared/PrivacyToggle.jsx";
 import { useToast } from "@/components/ui/use-toast";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/shared/PrivacyToggle.js.jsx
+++ b/shared/PrivacyToggle.js.jsx
@@ -1,1 +1,1 @@
-export default function PrivacyToggle.js() { return null; }
+export { default } from "./PrivacyToggle.jsx";


### PR DESCRIPTION
## Summary
- replace the stubbed `PrivacyToggle.js.jsx` implementation with a re-export of the real JSX module
- update dashboard, layout, and settings imports to point directly at `PrivacyToggle.jsx`

## Testing
- npm run build *(fails: Vite cannot resolve /src/main.jsx from index.html in the current project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e06f95d820833182105254d9d1be10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized component imports to use .jsx extensions for consistency across the app.
  * Introduced a compatibility re-export to align the component’s public entry point without changing its interface.

* **Chores**
  * Cleaned up import paths to reduce confusion and future integration issues.

No user-facing changes; behavior and UI remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->