### PR TITLE
Pass shift data to monthly comparison analytics

### DIFF
--- a/pages/Analytics.jsx
+++ b/pages/Analytics.jsx
@@ -97,6 +97,7 @@ export default function AnalyticsPage() {
                             <div className="min-h-[400px]">
                                 <MonthlyComparison
                                     transactions={transactions}
+                                    shifts={shifts}
                                     isLoading={isLoading}
                                 />
                             </div>

--- a/pages/FinancialPlanning.jsx
+++ b/pages/FinancialPlanning.jsx
@@ -293,6 +293,7 @@ export default function FinancialPlanningPage() {
                                         <div className="min-h-[400px]">
                                             <MonthlyComparison
                                                 transactions={transactions}
+                                                shifts={shifts}
                                                 isLoading={dataLoading}
                                             />
                                         </div>


### PR DESCRIPTION
## Summary
- ensure the analytics page forwards shift data into the monthly comparison component alongside transactions
- update the financial planning analytics tab so monthly comparison receives shift information as well

## Testing
- npm run build *(fails: Vite cannot resolve /src/main.jsx from index.html in this workspace layout)*

------
https://chatgpt.com/codex/tasks/task_e_68e06fb567808331b86a698634fedcc1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Analytics and Financial Planning pages to pass shift data into the Monthly Comparison component.
  * Standardized prop usage for consistency across pages.

* **Chores**
  * Internal data flow adjustments to support the Monthly Comparison component with shifts information.

* **Notes**
  * No user-facing changes or behavioral differences observed.
  * Existing functionality and layouts remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->