### PR TITLE
Normalize route URLs to slug format

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,4 +1,5 @@
 import Layout from "./Layout.jsx";
+import { createPageUrl } from "@/utils";
 
 import Transactions from "./Transactions";
 
@@ -115,7 +116,10 @@ function _getCurrentPage(url) {
         urlLastPart = urlLastPart.split('?')[0];
     }
 
-    const pageName = Object.keys(PAGES).find(page => page.toLowerCase() === urlLastPart.toLowerCase());
+    const normalizedUrlPart = urlLastPart.toLowerCase();
+    const pageName = Object.keys(PAGES).find(
+        (page) => createPageUrl(page).slice(1) === normalizedUrlPart
+    );
     return pageName || Object.keys(PAGES)[0];
 }
 
@@ -126,61 +130,15 @@ function PagesContent() {
     
     return (
         <Layout currentPageName={currentPage}>
-            <Routes>            
-                
-                    <Route path="/" element={<Transactions />} />
-                
-                
-                <Route path="/Transactions" element={<Transactions />} />
-                
-                <Route path="/FileUpload" element={<FileUpload />} />
-                
-                <Route path="/BNPL" element={<BNPL />} />
-                
-                <Route path="/Shifts" element={<Shifts />} />
-                
-                <Route path="/Calendar" element={<Calendar />} />
-                
-                <Route path="/DebtPlanner" element={<DebtPlanner />} />
-                
-                <Route path="/AIAdvisor" element={<AIAdvisor />} />
-                
-                <Route path="/Budget" element={<Budget />} />
-                
-                <Route path="/Goals" element={<Goals />} />
-                
-                <Route path="/Paycheck" element={<Paycheck />} />
-                
-                <Route path="/Analytics" element={<Analytics />} />
-                
-                <Route path="/Reports" element={<Reports />} />
-                
-                <Route path="/ShiftRules" element={<ShiftRules />} />
-                
-                <Route path="/Agents" element={<Agents />} />
-                
-                <Route path="/Scanner" element={<Scanner />} />
-                
-                <Route path="/WorkHub" element={<WorkHub />} />
-                
-                <Route path="/DebtControl" element={<DebtControl />} />
-                
-                <Route path="/FinancialPlanning" element={<FinancialPlanning />} />
-                
-                <Route path="/AIAssistant" element={<AIAssistant />} />
-                
-                <Route path="/Settings" element={<Settings />} />
-                
-                <Route path="/MoneyManager" element={<MoneyManager />} />
-                
-                <Route path="/UnifiedCalendar" element={<UnifiedCalendar />} />
-                
-                <Route path="/Dashboard" element={<Dashboard />} />
-                
-                <Route path="/Diagnostics" element={<Diagnostics />} />
-                
-                <Route path="/Pricing" element={<Pricing />} />
-                
+            <Routes>
+                <Route path="/" element={<Transactions />} />
+                {Object.entries(PAGES).map(([pageName, Component]) => (
+                    <Route
+                        key={pageName}
+                        path={createPageUrl(pageName)}
+                        element={<Component />}
+                    />
+                ))}
             </Routes>
         </Layout>
     );

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,6 +1,10 @@
-
-
-
 export function createPageUrl(pageName: string) {
-    return '/' + pageName.toLowerCase().replace(/ /g, '-');
+    const slug = pageName
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .replace(/[\s_]+/g, "-")
+        .replace(/-+/g, "-")
+        .toLowerCase()
+        .replace(/^-|-$/g, "");
+
+    return `/${slug}`;
 }


### PR DESCRIPTION
## Summary
- update `createPageUrl` to generate lowercase slug paths from page names
- switch the router in `pages/index.jsx` to rely on `createPageUrl`, keeping the current page detection in sync

## Testing
- npm run dev -- --host 0.0.0.0 --port 4174

------
https://chatgpt.com/codex/tasks/task_e_68e06fa8d9d483318633ef6ba37a298c