### PR TITLE
Add agent SDK shim and align page imports

### DIFF
--- a/agents/index.js
+++ b/agents/index.js
@@ -1,0 +1,164 @@
+const listeners = new Map();
+const conversations = new Map();
+
+const generateId = () => `conv_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+const generateMessageId = () => `msg_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+
+const cloneConversation = (conversation) => JSON.parse(JSON.stringify(conversation));
+
+const ensureConversation = (conversation) => {
+  if (!conversation || !conversation.id) {
+    throw new Error('Conversation not found');
+  }
+  if (!conversations.has(conversation.id)) {
+    conversations.set(conversation.id, cloneConversation(conversation));
+  }
+  return conversations.get(conversation.id);
+};
+
+const resolveConversation = async (conversationOrId) => {
+  const maybePromise = await Promise.resolve(conversationOrId);
+  if (!maybePromise) {
+    return null;
+  }
+  if (typeof maybePromise === 'string') {
+    return conversations.get(maybePromise) || null;
+  }
+  return ensureConversation(maybePromise);
+};
+
+const notifyListeners = (conversation) => {
+  const callbacks = listeners.get(conversation.id);
+  if (!callbacks) {
+    return;
+  }
+  const snapshot = cloneConversation(conversation);
+  callbacks.forEach((callback) => {
+    try {
+      callback(snapshot);
+    } catch (error) {
+      console.error('agentSDK listener error', error);
+    }
+  });
+};
+
+const generateAssistantReply = (conversation, lastUserMessage) => {
+  const prompt = lastUserMessage?.content || '';
+
+  if (!prompt.trim()) {
+    return 'I received your message. How can I help you explore your finances today?';
+  }
+
+  if (/budget/i.test(prompt)) {
+    return 'Consider setting aside categories for essentials, savings, and goals. I can help you break them down further.';
+  }
+
+  if (/debt|loan|credit/i.test(prompt)) {
+    return 'Let\'s review your debts and prioritize high-interest balances first. I can outline a payoff strategy if you\'d like.';
+  }
+
+  if (/invest|retire|growth/i.test(prompt)) {
+    return 'Diversifying across tax-advantaged accounts and recurring contributions can accelerate progress. Want a tailored plan?';
+  }
+
+  return `Thanks for the insight! I\'ll analyze: "${prompt.slice(0, 160)}" and follow up with actionable suggestions.`;
+};
+
+const agentSDK = {
+  async createConversation({ agent_name, metadata = {} } = {}) {
+    const id = generateId();
+    const now = new Date().toISOString();
+    const conversation = {
+      id,
+      agent_name: agent_name || 'financial_advisor',
+      metadata: {
+        ...metadata,
+        created_at: metadata.created_at || now,
+      },
+      created_at: now,
+      updated_at: now,
+      messages: [],
+    };
+
+    conversations.set(id, cloneConversation(conversation));
+    notifyListeners(conversation);
+    return cloneConversation(conversation);
+  },
+
+  async listConversations({ agent_name } = {}) {
+    const results = Array.from(conversations.values())
+      .filter((conversation) => {
+        if (!agent_name) return true;
+        return conversation.agent_name === agent_name;
+      })
+      .sort((a, b) => new Date(b.updated_at || 0) - new Date(a.updated_at || 0))
+      .map((conversation) => cloneConversation(conversation));
+
+    return results;
+  },
+
+  async addMessage(conversationOrId, message) {
+    const conversation = await resolveConversation(conversationOrId);
+    if (!conversation) {
+      throw new Error('Conversation not found');
+    }
+
+    const now = new Date().toISOString();
+    const normalizedMessage = {
+      id: message.id || generateMessageId(),
+      role: message.role || 'user',
+      content: message.content || '',
+      created_at: now,
+      tool_calls: message.tool_calls,
+      metadata: message.metadata,
+    };
+
+    conversation.messages = [...(conversation.messages || []), normalizedMessage];
+    conversation.updated_at = now;
+
+    conversations.set(conversation.id, cloneConversation(conversation));
+    notifyListeners(conversation);
+
+    if (normalizedMessage.role === 'user') {
+      const assistantMessage = {
+        id: generateMessageId(),
+        role: 'assistant',
+        content: generateAssistantReply(conversation, normalizedMessage),
+        created_at: new Date().toISOString(),
+      };
+
+      conversation.messages = [...conversation.messages, assistantMessage];
+      conversation.updated_at = new Date().toISOString();
+      conversations.set(conversation.id, cloneConversation(conversation));
+      notifyListeners(conversation);
+    }
+
+    return cloneConversation(conversation);
+  },
+
+  subscribeToConversation(conversationId, callback) {
+    if (!listeners.has(conversationId)) {
+      listeners.set(conversationId, new Set());
+    }
+
+    const callbacks = listeners.get(conversationId);
+    callbacks.add(callback);
+
+    const currentConversation = conversations.get(conversationId);
+    if (currentConversation) {
+      callback(cloneConversation(currentConversation));
+    }
+
+    return () => {
+      const current = listeners.get(conversationId);
+      if (!current) return;
+      current.delete(callback);
+      if (current.size === 0) {
+        listeners.delete(conversationId);
+      }
+    };
+  },
+};
+
+export { agentSDK };
+export default agentSDK;

--- a/components/ui/sonner.jsx
+++ b/components/ui/sonner.jsx
@@ -1,0 +1,29 @@
+"use client";
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, toast } from "sonner"
+
+const Toaster = ({
+  ...props
+}) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    (<Sonner
+      theme={theme}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props} />)
+  );
+}
+
+export { Toaster, toast }

--- a/components/ui/toaster.jsx
+++ b/components/ui/toaster.jsx
@@ -1,0 +1,8 @@
+import { Toaster as SonnerToaster } from "@/components/ui/sonner";
+
+const Toaster = (props) => {
+  return <SonnerToaster {...props} />;
+};
+
+export { Toaster };
+export default Toaster;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,54 +1,54 @@
-import Layout from "./Layout.jsx";
+import Layout from "@/pages/Layout.jsx";
 
-import Transactions from "./Transactions";
+import Transactions from "@/pages/Transactions.jsx";
 
-import FileUpload from "./FileUpload";
+import FileUpload from "@/pages/FileUpload.jsx";
 
-import BNPL from "./BNPL";
+import BNPL from "@/pages/BNPL.jsx";
 
-import Shifts from "./Shifts";
+import Shifts from "@/pages/Shifts.jsx";
 
-import Calendar from "./Calendar";
+import Calendar from "@/pages/Calendar.jsx";
 
-import DebtPlanner from "./DebtPlanner";
+import DebtPlanner from "@/pages/DebtPlanner.jsx";
 
-import AIAdvisor from "./AIAdvisor";
+import AIAdvisor from "@/pages/AIAdvisor.jsx";
 
-import Budget from "./Budget";
+import Budget from "@/pages/Budget.jsx";
 
-import Goals from "./Goals";
+import Goals from "@/pages/Goals.jsx";
 
-import Paycheck from "./Paycheck";
+import Paycheck from "@/pages/Paycheck.jsx";
 
-import Analytics from "./Analytics";
+import Analytics from "@/pages/Analytics.jsx";
 
-import Reports from "./Reports";
+import Reports from "@/pages/Reports.jsx";
 
-import ShiftRules from "./ShiftRules";
+import ShiftRules from "@/pages/ShiftRules.jsx";
 
-import Agents from "./Agents";
+import Agents from "@/pages/Agents.jsx";
 
-import Scanner from "./Scanner";
+import Scanner from "@/pages/Scanner.jsx";
 
-import WorkHub from "./WorkHub";
+import WorkHub from "@/pages/WorkHub.jsx";
 
-import DebtControl from "./DebtControl";
+import DebtControl from "@/pages/DebtControl.jsx";
 
-import FinancialPlanning from "./FinancialPlanning";
+import FinancialPlanning from "@/pages/FinancialPlanning.jsx";
 
-import AIAssistant from "./AIAssistant";
+import AIAssistant from "@/pages/AIAssistant.jsx";
 
-import Settings from "./Settings";
+import Settings from "@/pages/Settings.jsx";
 
-import MoneyManager from "./MoneyManager";
+import MoneyManager from "@/pages/MoneyManager.jsx";
 
-import UnifiedCalendar from "./UnifiedCalendar";
+import UnifiedCalendar from "@/pages/UnifiedCalendar.jsx";
 
-import Dashboard from "./Dashboard";
+import Dashboard from "@/pages/Dashboard.jsx";
 
-import Diagnostics from "./Diagnostics";
+import Diagnostics from "@/pages/Diagnostics.jsx";
 
-import Pricing from "./Pricing";
+import Pricing from "@/pages/Pricing.jsx";
 
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 


### PR DESCRIPTION
## Summary
- add an in-memory `agentSDK` shim under `agents/index.js` so AI-driven pages can resolve their SDK imports
- switch the page index to the project-level `@/pages/...` aliases for consistency with the new aliasing scheme
- expose the Sonner `toast` helper and a lightweight Toaster wrapper from `@/components/ui` to satisfy the updated toast utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06fa6b234833194118001c4aee6f9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added theme-aware toast notifications with consistent styling.
  - Enabled creating and viewing conversations with automatic assistant replies.
  - Real-time updates to conversation views when messages are added.

- Refactor
  - Updated internal module paths for improved consistency and maintainability.

- Chores
  - Introduced a unified Toaster component and toast utility for app-wide notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->