### PR TITLE
Normalize route slugs

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -152,14 +152,27 @@ function PagesContent() {
     return (
         <Layout currentPageName={currentPage}>
             <Routes>
-                <Route path="/" element={<Transactions />} />
-                {Object.entries(PAGES).map(([pageName, Component]) => (
+// At the top of pages/index.jsx, update the import:
+import { BrowserRouter as Router, Route, Routes, useLocation, Navigate } from 'react-router-dom';
+
+// …later, inside your JSX…
+             <Routes>
+                 <Route path="/" element={<Transactions />} />
+                 {Object.entries(PAGES).map(([pageName, Component]) => (
+                     <Route
+                         key={pageName}
+                         path={createPageUrl(pageName)}
+                         element={<Component />}
+                     />
+                 ))}
+                {Object.keys(PAGES).map((pageName) => (
                     <Route
-                        key={pageName}
-                        path={createPageUrl(pageName)}
-                        element={<Component />}
+                        key={`${pageName}-legacy`}
+                        path={`/${pageName}`}
+                        element={<Navigate to={createPageUrl(pageName)} replace />}
                     />
                 ))}
+             </Routes>
             </Routes>
         </Layout>
     );

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -50,6 +50,7 @@ import Diagnostics from "./Diagnostics";
 
 import Pricing from "./Pricing";
 
+import { createPageUrl } from "@/utils";
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
 const PAGES = {
@@ -107,16 +108,31 @@ const PAGES = {
 }
 
 function _getCurrentPage(url) {
+    const pageNames = Object.keys(PAGES);
+    const defaultPage = pageNames[0];
+
+    if (!url) {
+        return defaultPage;
+    }
+
     if (url.endsWith('/')) {
         url = url.slice(0, -1);
     }
-    let urlLastPart = url.split('/').pop();
+    let urlLastPart = url.split('/').pop() || '';
     if (urlLastPart.includes('?')) {
         urlLastPart = urlLastPart.split('?')[0];
     }
 
-    const pageName = Object.keys(PAGES).find(page => page.toLowerCase() === urlLastPart.toLowerCase());
-    return pageName || Object.keys(PAGES)[0];
+    if (!urlLastPart) {
+        return defaultPage;
+    }
+
+    const normalizedSegment = urlLastPart.toLowerCase();
+    const pageName = pageNames.find(
+        (page) => createPageUrl(page).slice(1) === normalizedSegment
+    );
+
+    return pageName || defaultPage;
 }
 
 // Create a wrapper component that uses useLocation inside the Router context
@@ -126,61 +142,15 @@ function PagesContent() {
     
     return (
         <Layout currentPageName={currentPage}>
-            <Routes>            
-                
-                    <Route path="/" element={<Transactions />} />
-                
-                
-                <Route path="/transactions" element={<Transactions />} />
-
-                <Route path="/fileupload" element={<FileUpload />} />
-
-                <Route path="/bnpl" element={<BNPL />} />
-
-                <Route path="/shifts" element={<Shifts />} />
-
-                <Route path="/calendar" element={<Calendar />} />
-
-                <Route path="/debtplanner" element={<DebtPlanner />} />
-
-                <Route path="/aiadvisor" element={<AIAdvisor />} />
-
-                <Route path="/budget" element={<Budget />} />
-
-                <Route path="/goals" element={<Goals />} />
-
-                <Route path="/paycheck" element={<Paycheck />} />
-
-                <Route path="/analytics" element={<Analytics />} />
-
-                <Route path="/reports" element={<Reports />} />
-
-                <Route path="/shiftrules" element={<ShiftRules />} />
-
-                <Route path="/agents" element={<Agents />} />
-
-                <Route path="/scanner" element={<Scanner />} />
-
-                <Route path="/workhub" element={<WorkHub />} />
-
-                <Route path="/debtcontrol" element={<DebtControl />} />
-
-                <Route path="/financialplanning" element={<FinancialPlanning />} />
-
-                <Route path="/aiassistant" element={<AIAssistant />} />
-
-                <Route path="/settings" element={<Settings />} />
-
-                <Route path="/moneymanager" element={<MoneyManager />} />
-
-                <Route path="/unifiedcalendar" element={<UnifiedCalendar />} />
-
-                <Route path="/dashboard" element={<Dashboard />} />
-
-                <Route path="/diagnostics" element={<Diagnostics />} />
-
-                <Route path="/pricing" element={<Pricing />} />
-                
+            <Routes>
+                <Route path="/" element={<Transactions />} />
+                {Object.entries(PAGES).map(([pageName, Component]) => (
+                    <Route
+                        key={pageName}
+                        path={createPageUrl(pageName)}
+                        element={<Component />}
+                    />
+                ))}
             </Routes>
         </Layout>
     );

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,5 +2,14 @@
 
 
 export function createPageUrl(pageName: string) {
-    return '/' + pageName.toLowerCase().replace(/ /g, '-');
+    const slug = pageName
+        // Insert hyphen between lowercase/number followed by uppercase
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        // Handle transitions from multiple uppercase letters to title case words (e.g., AIAssistant)
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+        // Normalize spaces and underscores to hyphens
+        .replace(/[\s_]+/g, '-')
+        .toLowerCase();
+
+    return `/${slug}`;
 }


### PR DESCRIPTION
## Summary
- convert `createPageUrl` to emit lowercase, hyphenated slugs derived from PascalCase names
- drive the router from `createPageUrl` so every route path matches the canonical slug format and current-page detection resolves hyphenated segments

## Testing
- `npm run build` *(fails: vite cannot resolve /src/main.jsx in this repository layout)*
- `npm run dev -- --host 0.0.0.0 --port 4173` *(serves but navigation testing is blocked because /src/main.jsx 404s, so the UI never renders)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b6d2e1008331bd199fa76109475e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic URL-based page routing with automatic fallback to a default page.
  * Cleaner, consistent page URLs generated from page names (handles camelCase, acronyms, underscores, spaces).

* **Bug Fixes**
  * More reliable navigation when URLs include trailing slashes or query strings.
  * Fewer unexpected “page not found” cases via normalized and validated URL segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->